### PR TITLE
Add support for multiple `run_at` attribute 

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Documentation can be found at [https://hexdocs.pm/gen_worker](https://hexdocs.pm
 ## Supported options
 *`run_at`* – keyword list with integers values. Supported keys: `:year`, `:month`, `:day`, `:hour`, `:minute`, `:second`, `:microsecond`.
 
+Or you can use map for multiple runs:
+
+```elixir
+use GenWorker, run_at: %{"some_key" => [hour: 13, minute: 59], "other_key" => [hour: 14, minute: 00]}, run_each: [days: 1]
+```
+
 *`run_each`* - keyword list with integers values. Supported keys: `:years`, `:months`, `:weeks`, `:days`, `:hours`, `:minutes`, `:seconds`, `:milliseconds`. *Default: `[days: 1]`*.
 
 *`timezone`* - valid timezone. *Default: `:utc`*.

--- a/lib/gen_worker.ex
+++ b/lib/gen_worker.ex
@@ -1,7 +1,7 @@
 defmodule GenWorker do
   @moduledoc """
   Generic Worker behavior that helps to run task at a specific time with a specified frequency.
-  
+
 
   ## Usage
   Define you worker module
@@ -17,8 +17,14 @@ defmodule GenWorker do
   ```
 
   ### Supported options
-  *`run_at`* – keyword list with integers values. Supported keys: 
+  *`run_at`* – keyword list with integers values. Supported keys:
    `:year`, `:month`, `:day`, `:hour`, `:minute`, `:second`, `:microsecond`.
+
+    Or you can use map for multiple runs:
+
+    ```elixir
+    use GenWorker, run_at: %{"some_key" => [hour: 13, minute: 59], "other_key" => [hour: 14, minute: 00]}, run_each: [days: 1]
+    ```
 
   *`run_each`* - keyword list with integers values. Supported keys: `:years`, `:months`, `:weeks`, `:days`, `:hours`, `:minutes`, `:seconds`, `:milliseconds`. Default is `[days: 1]`
 
@@ -26,7 +32,7 @@ defmodule GenWorker do
 
 
   You need to implement callback function:
-  `c:run/1` that defines worker business logic  
+  `c:run/1` that defines worker business logic
 
    ### Add worker to the application supervision tree:
   ```elixir
@@ -52,7 +58,7 @@ defmodule GenWorker do
   @doc false
   defmacro __using__(opts) do
     quote bind_quoted: [opts: opts], location: :keep do
-      @behaviour GenWorker 
+      @behaviour GenWorker
       @options opts
 
       alias GenWorker.State
@@ -65,7 +71,7 @@ defmodule GenWorker do
           |> Keyword.put(:caller, __MODULE__)
           |> Keyword.put(:worker_args, params)
           |> State.init!()
-        
+
         GenServer.start_link(GenWorker.Server, state, name: __MODULE__)
       end
 

--- a/lib/gen_worker/server.ex
+++ b/lib/gen_worker/server.ex
@@ -5,7 +5,7 @@ defmodule GenWorker.Server do
 
   alias GenWorker.{State, Error}
 
-  @spec init(State.t) :: {:ok, State.t}
+  @spec init(State.t()) :: {:ok, State.t()}
   def init(state) do
     Logger.debug("GenWorker: Init worker with state: #{inspect(state)}")
     schedule_work(state)
@@ -13,48 +13,63 @@ defmodule GenWorker.Server do
   end
 
   @doc false
-  @spec handle_info(:run_work, State.t) :: {:noreply, State.t}
-  def handle_info(:run_work, %{caller: caller, worker_args: worker_args}=state) do
+  @spec handle_info({:run_work, binary() | atom()}, State.t()) :: {:noreply, State.t()}
+  def handle_info(
+        {:run_work, key},
+        %{caller: caller, worker_args: worker_args, run_at: run_at} = state
+      ) do
     updated_args = caller.run(worker_args)
-    
-    schedule_work(state)
-    updated_state = state
+
+    calc_one_work(run_at[key], key, state)
+
+    updated_state =
+      state
       |> Map.put(:last_called_at, time_now(state))
       |> Map.put(:worker_args, updated_args)
 
     {:noreply, updated_state}
   end
 
-  @spec delay_in_msec(DateTime.t, State.t) :: integer()
-  def delay_in_msec(current_time, %State{run_at: run_at, run_each: run_each, last_called_at: last_called_at}) do    
+  @spec delay_in_msec(DateTime.t(), State.run_at_options(), State.t()) :: integer()
+  def delay_in_msec(current_time, run_at, %State{
+        run_each: run_each,
+        last_called_at: last_called_at
+      }) do
     current_time
     |> Timex.set(run_at)
     |> (fn call_at ->
           if Timex.before?(current_time, call_at) &&
-                (last_called_at == nil || Timex.before?(call_at, last_called_at)) do
+               (last_called_at == nil || Timex.before?(call_at, last_called_at)) do
             call_at
           else
             Timex.shift(call_at, run_each)
           end
-    end).()
+        end).()
     |> Timex.diff(current_time, :milliseconds)
   end
 
-  @spec schedule_work(State.t) :: :ok
-  defp schedule_work(%State{}=state) do
-    call_after_msec = delay_in_msec(time_now(state), state)
-    Logger.debug("GenWorker run worker after #{call_after_msec} msec")
-    Process.send_after(self(), :run_work, call_after_msec)
+  @spec schedule_work(State.t()) :: :ok
+  defp schedule_work(%State{run_at: run_at} = state) do
+    for {key, time} <- run_at do
+      calc_one_work(time, key, state)
+    end
+
     :ok
   end
 
-  @spec time_now(State.t) :: DateTime.t | no_return()
+  @spec calc_one_work(State.run_at_options(), binary() | atom(), State.t()) :: reference()
+  defp calc_one_work(time, key, state) do
+    call_after_msec = delay_in_msec(time_now(state), time, state)
+    Logger.debug("GenWorker run worker \"#{key}\" after #{call_after_msec} msec")
+    Process.send_after(self(), {:run_work, key}, call_after_msec)
+  end
+
+  @spec time_now(State.t()) :: DateTime.t() | no_return()
   defp time_now(%State{timezone: timezone}) do
     Timex.now(timezone)
     |> case do
-      %DateTime{}=datetime -> datetime
-      {:error, reason} -> raise Error, "Error invalid timezone #{timezone}: #{inspect reason}"
+      %DateTime{} = datetime -> datetime
+      {:error, reason} -> raise Error, "Error invalid timezone #{timezone}: #{inspect(reason)}"
     end
   end
-
 end

--- a/lib/gen_worker/state.ex
+++ b/lib/gen_worker/state.ex
@@ -6,50 +6,50 @@ defmodule GenWorker.State do
 
   @default_run_each [days: 1]
   @default_run_at [{:microsecond, {1, 0}}]
-  
-  @typep run_at_options() :: [
-    date: Timex.Types.date(),
-    year: Timex.Types.year(),
-    month: Timex.Types.month(),
-    day: Timex.Types.day(),
-    hour: Timex.Types.hour(),
-    minute: Timex.Types.minute(),
-    second: Timex.Types.second(),
-    microsecond: Timex.Types.microsecond()
-  ]
+
+  @type run_at_options() :: [
+           date: Timex.Types.date(),
+           year: Timex.Types.year(),
+           month: Timex.Types.month(),
+           day: Timex.Types.day(),
+           hour: Timex.Types.hour(),
+           minute: Timex.Types.minute(),
+           second: Timex.Types.second(),
+           microsecond: Timex.Types.microsecond()
+         ]
 
   @typep run_each_options :: [
-    microseconds: integer(),
-    milliseconds: integer(),
-    seconds: integer(),
-    minutes: integer(),
-    hours: integer(),
-    days: integer(),
-    weeks: integer(),
-    months: integer(),
-    years: integer()
-  ]
+           microseconds: integer(),
+           milliseconds: integer(),
+           seconds: integer(),
+           minutes: integer(),
+           hours: integer(),
+           days: integer(),
+           weeks: integer(),
+           months: integer(),
+           years: integer()
+         ]
 
   @type t :: %__MODULE__{
-    run_at: run_at_options(),
-    run_each: run_each_options(),
-    caller: atom(),
-    timezone: Timex.TimezoneInfo.t,
-    last_called_at: DateTime.t(),
-    worker_args: term()
-  }
+          run_at: run_at_options(),
+          run_each: run_each_options(),
+          caller: atom(),
+          timezone: Timex.TimezoneInfo.t(),
+          last_called_at: DateTime.t(),
+          worker_args: term()
+        }
 
   @type options :: [
-    run_at: run_at_options(),
-    run_each: run_each_options()
-  ]
+          run_at: run_at_options() | %{(binary() | atom()) => run_at_options(), ...},
+          run_each: run_each_options()
+        ]
 
   defstruct [:run_at, :caller, :run_each, :last_called_at, :timezone, :worker_args]
 
   @doc """
   Init state structure and validate
   """
-  @spec init!(options) :: State.t() | no_return()  | Exception.t
+  @spec init!(options) :: State.t() | no_return() | Exception.t()
   def init!(options) do
     %State{
       caller: options[:caller],
@@ -60,13 +60,23 @@ defmodule GenWorker.State do
     }
   end
 
-  defp validate_run_at!(run_at) when is_nil(run_at) do
-    @default_run_at
+  defp validate_run_at!(run_at) when is_nil(run_at),
+    do: %{"default" => @default_run_at}
+
+  defp validate_run_at!(run_at) when is_list(run_at),
+    do: %{"default" => run_at_validator!(run_at)}
+
+  defp validate_run_at!(run_at) when is_map(run_at) do
+    Map.values(run_at) |> Enum.each(&run_at_validator!/1)
+    run_at
   end
-  defp validate_run_at!(run_at) do
+
+  defp run_at_validator!(run_at) do
     case Timex.set(Timex.now(), run_at) do
-      %DateTime{} -> Keyword.put_new(run_at, :microsecond, {1, 0})
-      {:error, {:bad_option, bad_option}}->
+      %DateTime{} ->
+        Keyword.put_new(run_at, :microsecond, {1, 0})
+
+      {:error, {:bad_option, bad_option}} ->
         raise Error, "Error invalid `#{bad_option}` run_at option."
     end
   end
@@ -74,9 +84,12 @@ defmodule GenWorker.State do
   defp validate_run_each!(nil) do
     @default_run_each
   end
+
   defp validate_run_each!(run_each) do
-    case Timex.shift(Timex.now, run_each) do
-      %DateTime{} -> run_each
+    case Timex.shift(Timex.now(), run_each) do
+      %DateTime{} ->
+        run_each
+
       {:error, {:unknown_shift_unit, bad_option}} ->
         raise Error, "Error invalid `#{bad_option}` run_each option."
     end
@@ -85,6 +98,7 @@ defmodule GenWorker.State do
   defp validate_timezone!(nil) do
     Application.get_env(:gen_worker, :timezone, :utc)
   end
+
   defp validate_timezone!(timezone) do
     if not Timex.is_valid_timezone?(timezone) do
       raise Error, "Error invalid `#{timezone}` timezone."
@@ -92,5 +106,4 @@ defmodule GenWorker.State do
 
     timezone
   end
-
 end


### PR DESCRIPTION
Hi! I added support for for multiple definition `run_at` attribute. This neded, eg, for run subscriptions in plann time
```elixir
use GenWorker,
    run_at: %{
      "700" => [hour: 7, minute: 00, second: 1],
      "15" => [hour: 7, minute: 15, second: 1],
      "30" => [hour: 7, minute: 30, second: 1],
      "45" => [hour: 7, minute: 45, second: 1],
      "800" => [hour: 8, minute: 00, second: 1]
    },
    run_each: [days: 1],
    timezone: "Europe/Moscow"
```